### PR TITLE
make solium usable as a pre-commit framework hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+-   id: solium
+    name: Run solium linter
+    description: This runs the solium linter.
+    entry: solium
+    args: [--dir=.]
+    language: node
+    types: [text]


### PR DESCRIPTION
pre-commit is a framework for managing and maintaining multi-language pre-commit
hooks. Visit https://pre-commit.com/ for more information.

With this single configuration file here, it's easily possible to use solium as
a pre-commit hook.