### PR TITLE
Quotes in return() string can be linted and fixed

### DIFF
--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-let jsStringEscape = require("js-string-escape");
+const jsStringEscape = require("js-string-escape");
 
 /**
  * Determine whether the provided literal is in Hex Notation
@@ -51,7 +51,7 @@ module.exports = {
             quoteStyle = "single";
         }
 
-        const selectedQuoteStyleLiteralRegExp = new RegExp("^\\" + quote + ".*\\" + quote + "$" + "|^\\(\\" + quote + ".*\\" + quote + "\\)$");
+        const selectedQuoteStyleLiteralRegExp = new RegExp("^(\\(\\s*)?\\" + quote + ".*\\" + quote + "(\\s*\\))?$");
 
 
         function inspectLiteral(emitted) {
@@ -63,15 +63,18 @@ module.exports = {
             }
 
             if (!selectedQuoteStyleLiteralRegExp.test(nodeText)) {
-                let fixedString = quote + jsStringEscape(node.value) + quote;
-                if(nodeText[0] == "(" && nodeText[nodeText.length - 1] == ")")
-                    fixedString = "(" + fixedString + ")";
                 const errorObject = {
                     node,
                     fix(fixer) {
-                        return fixer.replaceText(node, fixedString);
+                        const fixedString = quote + jsStringEscape(node.value) + quote,
+                            currentQuote = (quote === "'" ? "\"" : "'");
+                        const openingQuoteI = nodeText.indexOf(currentQuote),
+                            closingQuoteI = nodeText.lastIndexOf(currentQuote);
+                        const fixedNodeText = nodeText.slice(0, openingQuoteI) + fixedString + nodeText.slice(closingQuoteI+1);
+
+                        return fixer.replaceText(node, fixedNodeText);
                     },
-                    message: `'${node.value}': String literal must be quoted with ${quoteStyle} quotes.`
+                    message: `String literal must be quoted with ${quoteStyle} quotes.`
                 };
 
                 context.report(errorObject);

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -64,8 +64,8 @@ module.exports = {
 
             if (!selectedQuoteStyleLiteralRegExp.test(nodeText)) {
                 let fixedString = quote + jsStringEscape(node.value) + quote;
-                if(nodeText[0] == '(' && nodeText[nodeText.length - 1] == ')')
-                    fixedString = '(' + fixedString + ')';
+                if(nodeText[0] == "(" && nodeText[nodeText.length - 1] == ")")
+                    fixedString = "(" + fixedString + ")";
                 const errorObject = {
                     node,
                     fix(fixer) {

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -51,7 +51,7 @@ module.exports = {
             quoteStyle = "single";
         }
 
-        const selectedQuoteStyleLiteralRegExp = new RegExp("^\\" + quote + ".*\\" + quote + "$");
+        const selectedQuoteStyleLiteralRegExp = new RegExp("^\\" + quote + ".*\\" + quote + "$" + "|^\\(\\" + quote + ".*\\" + quote + "\\)$");
 
 
         function inspectLiteral(emitted) {
@@ -64,6 +64,8 @@ module.exports = {
 
             if (!selectedQuoteStyleLiteralRegExp.test(nodeText)) {
                 let fixedString = quote + jsStringEscape(node.value) + quote;
+                if(nodeText[0] == '(' && nodeText[nodeText.length - 1] == ')')
+                    fixedString = '(' + fixedString + ')';
                 const errorObject = {
                     node,
                     fix(fixer) {

--- a/test/lib/rules/quotes/double-full.sol
+++ b/test/lib/rules/quotes/double-full.sol
@@ -12,6 +12,16 @@ contract Foo {
         function f () returns (string){
                 var foobar = "Hello world";
                 string fuu = "chumma";
+
+                var x = (                    "hello world"                 );
+                var x = (                       "hello world"          );
+                var x = (                    "hello world");
+                var x = ("hello world"        );
+
                 return ("Hello World");
+
+                return(
+                        "Lorem Ipsum"
+                );
         }
 }

--- a/test/lib/rules/quotes/double-full.sol
+++ b/test/lib/rules/quotes/double-full.sol
@@ -9,8 +9,9 @@ import "../myContract.sol" as MyContract;
 
 contract Foo {
         string fucker = "hello wordl";
-        function f () {
+        function f () returns (string){
                 var foobar = "Hello world";
                 string fuu = "chumma";
+                return ("Hello World");
         }
 }

--- a/test/lib/rules/quotes/quotes.js
+++ b/test/lib/rules/quotes/quotes.js
@@ -122,7 +122,7 @@ describe("[RULE] quotes: Fix when double quotes are mandatory", function() {
         fixed.errorMessages.should.be.Array();
         fixed.errorMessages.length.should.equal(0);
         fixed.fixesApplied.should.be.Array();
-        fixed.fixesApplied.length.should.equal(12);
+        fixed.fixesApplied.length.should.equal(17);
 
         Solium.reset();
         done();
@@ -189,7 +189,7 @@ describe("[RULE] quotes: Fix when single quotes are mandatory", function() {
         fixed.errorMessages.should.be.Array();
         fixed.errorMessages.length.should.equal(0);
         fixed.fixesApplied.should.be.Array();
-        fixed.fixesApplied.length.should.equal(12);
+        fixed.fixesApplied.length.should.equal(17);
 
         Solium.reset();
         done();

--- a/test/lib/rules/quotes/quotes.js
+++ b/test/lib/rules/quotes/quotes.js
@@ -122,7 +122,7 @@ describe("[RULE] quotes: Fix when double quotes are mandatory", function() {
         fixed.errorMessages.should.be.Array();
         fixed.errorMessages.length.should.equal(0);
         fixed.fixesApplied.should.be.Array();
-        fixed.fixesApplied.length.should.equal(11);
+        fixed.fixesApplied.length.should.equal(12);
 
         Solium.reset();
         done();
@@ -189,7 +189,7 @@ describe("[RULE] quotes: Fix when single quotes are mandatory", function() {
         fixed.errorMessages.should.be.Array();
         fixed.errorMessages.length.should.equal(0);
         fixed.fixesApplied.should.be.Array();
-        fixed.fixesApplied.length.should.equal(11);
+        fixed.fixesApplied.length.should.equal(12);
 
         Solium.reset();
         done();

--- a/test/lib/rules/quotes/single-full.sol
+++ b/test/lib/rules/quotes/single-full.sol
@@ -12,6 +12,16 @@ contract Foo {
         function f () returns (string){
                 var foobar = 'Hello world';
                 string fuu = 'chumma';
+
+                var x = (                    'hello world'                 );
+                var x = (                       'hello world'          );
+                var x = (                    'hello world');
+                var x = ('hello world'        );
+
                 return ('Hello World');
+
+                return(
+                        'Lorem Ipsum'
+                );
         }
 }

--- a/test/lib/rules/quotes/single-full.sol
+++ b/test/lib/rules/quotes/single-full.sol
@@ -9,8 +9,9 @@ import '../myContract.sol' as MyContract;
 
 contract Foo {
         string fucker = 'hello wordl';
-        function f () {
+        function f () returns (string){
                 var foobar = 'Hello world';
                 string fuu = 'chumma';
+                return ('Hello World');
         }
 }


### PR DESCRIPTION
fixes #240 

Updated regular expression to handle round brackets of return() string.

Also updated related tests and fixing.